### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/rob0236/a58f43d4-8791-4e02-bb03-ded69d8630fc/c6b9a65d-4b45-47b8-936e-3379dea01834/_apis/work/boardbadge/e311d0e4-d554-4226-985b-02172688e3e2)](https://dev.azure.com/rob0236/a58f43d4-8791-4e02-bb03-ded69d8630fc/_boards/board/t/c6b9a65d-4b45-47b8-936e-3379dea01834/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/rob0236/a58f43d4-8791-4e02-bb03-ded69d8630fc/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.